### PR TITLE
Eliminating cases in bash script

### DIFF
--- a/hws/intro/python/cryptomoney.sh
+++ b/hws/intro/python/cryptomoney.sh
@@ -52,3 +52,6 @@ case "$1" in
        ;;
 
 esac
+
+# Without the use of cases
+python3 cmoney.py $@


### PR DESCRIPTION
I think we can just use "$@" which basically pastes in all command line arguments instead of using cases. The only thing that'd need to change I guess would be handling the "name" command. I think the same would go for the Java bash script too.