### PR TITLE
Add P4 to due dates on UVA-specific page

### DIFF
--- a/uva/index.md
+++ b/uva/index.md
@@ -50,6 +50,7 @@ Unless otherwise noted, all submissions are due by the end of the day of the due
 
 #### Larger Programming Homeworks
 
+- Due Tue, 2/22, by midnight: [HW P4: Bitcoin scripting](../hws/btcscript/index.html) ([md](../hws/btcscript/index.md))
 - Due Tue, 2/15, by midnight: [HW P3: BTC parser](../hws/btcparser/index.html) ([md](../hws/btcparser/index.md))
 - Due Tue, 2/8, by midnight: [HW P2: ECDSA](../hws/ecdsa/index.html) ([md](../hws/ecdsa/index.md))
 - Due Tue, 2/1, by midnight: [HW P1: Overview](../hws/intro/index.html) ([md](../hws/intro/index.md))


### PR DESCRIPTION
P4 isn't currently listed as one of the assignments on the [course site](https://aaronbloomfield.github.io/ccc/uva/index.html) - I assume that the due date itself hasn't changed, so it should be added.